### PR TITLE
删除使用 Formatting API 时弹出的提示

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,6 @@ function activate(context) {
   context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('markdown', {
     provideDocumentFormattingEdits(document) {
       let content = documentFormatter.updateDocument(document);
-      vscode.window.showInformationMessage('MD格式化完毕!');
       return [new vscode.TextEdit(documentFormatter.current_document_range(document), content)];
     }
   }));


### PR DESCRIPTION
上次提交的代码里，我在 Format 结束时保留了提示。后面我发现其他的比如 Typescript，Python 的 Formatter 在使用 Shift + Alt + F 时都没有弹出提示。
个人感觉，按格式化快捷键习惯了之后，弹出提示确实挺分散注意力的。希望能在下一个版本里取消掉这个提示（不急，需要更新新版本的时候顺便取消掉提示就好）。感谢。_(:з」∠)_